### PR TITLE
Use gcloud deploy instead of appcfg.py

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,4 +7,4 @@ test check:
 	python -m unittest discover -p '*_test.py'
 
 appcfg-update deploy:
-	gcloud app deploy
+	gcloud app deploy --project "${APP}"

--- a/Makefile
+++ b/Makefile
@@ -7,4 +7,4 @@ test check:
 	python -m unittest discover -p '*_test.py'
 
 appcfg-update deploy:
-	appcfg.py -A "${APP}" update .
+	gcloud app deploy

--- a/README.md
+++ b/README.md
@@ -174,6 +174,12 @@ Your app will then be available at `mycompany-snippets.appspot.com`.
 If you get an error like 'gcloud: not found', it means you need to
 add the appengine-SDK location to your `$PATH`.
 
+You may also need to manually trigger an index build for datastore
+
+```
+gcloud datastore create-indexes index.yaml
+```
+
 
 Adding administrators
 ---------------------

--- a/README.md
+++ b/README.md
@@ -161,12 +161,10 @@ https://console.developers.google.com: click on "Select a project..."
 in the top navbar and then "Create a project."
 
 You will then need a name for your AppEngine project.  Let's suppose
-you call it `mycompany-snippets`. You must then set the project by 
-running `gcloud config set project mycompany-snippets` from the snippets
-directory. You can then deploy with
+you call it `mycompany-snippets`, you can then deploy with
 
 ```
-make deploy
+make deploy APP=mycompany-snippets
 ```
 
 Your app will then be available at `mycompany-snippets.appspot.com`.
@@ -179,6 +177,7 @@ You may also need to manually trigger an index build for datastore
 ```
 gcloud datastore create-indexes index.yaml
 ```
+(try this if you're seeing 500 errors)
 
 
 Adding administrators

--- a/README.md
+++ b/README.md
@@ -161,18 +161,17 @@ https://console.developers.google.com: click on "Select a project..."
 in the top navbar and then "Create a project."
 
 You will then need a name for your AppEngine project.  Let's suppose
-you call it `mycompany-snippets`.
+you call it `mycompany-snippets`. You must then set the project by 
+running `gcloud config set project mycompany-snippets` from the snippets
+directory. You can then deploy with
 
-After you have those pre-requisites, you can deploy this script in
-two easy steps:
 ```
-    git clone git@github.com/Khan/snippets
-    cd snippets && make deploy APP=mycompany-snippets
+make deploy
 ```
 
 Your app will then be available at `mycompany-snippets.appspot.com`.
 
-If you get an error like 'appcfg.py: not found', it means you need to
+If you get an error like 'gcloud: not found', it means you need to
 add the appengine-SDK location to your `$PATH`.
 
 

--- a/app.yaml
+++ b/app.yaml
@@ -1,4 +1,3 @@
-version: 1
 runtime: python27
 threadsafe: yes
 api_version: 1

--- a/templates/app_settings.html
+++ b/templates/app_settings.html
@@ -107,7 +107,7 @@
 </div>
 
 <div class="user-settings-block">
-  <label class="user-settings-label" for="slack_slash_token">Slack slash token:</label>
+  <label class="user-settings-label" for="slack_slash_token">Slack verificaiton token:</label>
   <input id="slack_slash_token" type="text" name="slack_slash_token" value="{{settings.slack_slash_token}}" class="user-settings-full-width-input">
   <p>If non-empty, enable slash-commands to work in Slack, to interact
   with snippets from within Slack.  Slack slash-commands can be
@@ -119,6 +119,10 @@
   <blockquote><pre>
 {{slack_slash_commands}}
   </pre></blockquote>
+  <p>
+   You will need to give the app "commands" permission scope and specify
+   https://mycomany-snippets.appspot.com/slack as the endpoint for /snippets
+  </p>
 </div>
 
 <input type="hidden" name="redirect_to" value="{{redirect_to}}">

--- a/templates/app_settings.html
+++ b/templates/app_settings.html
@@ -107,7 +107,7 @@
 </div>
 
 <div class="user-settings-block">
-  <label class="user-settings-label" for="slack_slash_token">Slack verificaiton token:</label>
+  <label class="user-settings-label" for="slack_slash_token">Slack verification token:</label>
   <input id="slack_slash_token" type="text" name="slack_slash_token" value="{{settings.slack_slash_token}}" class="user-settings-full-width-input">
   <p>If non-empty, enable slash-commands to work in Slack, to interact
   with snippets from within Slack.  Slack slash-commands can be


### PR DESCRIPTION
appcfg.py is deprecated/no longer supplied by the GAE toolkit, updated makefile and readme to reflect this

also, the datastore indexes didn't get created by default for me, added a note about that

also hi @mroth