### PR TITLE
Allow users to backfill snippets upto one week prior to their registration date.

### DIFF
--- a/snippets_test.py
+++ b/snippets_test.py
@@ -561,7 +561,7 @@ class UserSettingsTestCase(UserTestBase):
         self.request_fetcher.get(url)
 
         response = self.request_fetcher.get('/')
-        self.assertNumSnippets(response.body, 1)
+        self.assertNumSnippets(response.body, 2)
         response = self.request_fetcher.get('/weekly?week=02-27-2012')
         self.assertNumSnippets(response.body, 1)    # "no snippet this week"
 
@@ -569,7 +569,7 @@ class UserSettingsTestCase(UserTestBase):
         self.request_fetcher.get(url)
         response = self.request_fetcher.get('/')
         # Hiding doesn't affect the user-snippets page, just the weekly one.
-        self.assertNumSnippets(response.body, 1)
+        self.assertNumSnippets(response.body, 2)
         response = self.request_fetcher.get('/weekly?week=02-27-2012')
         self.assertNumSnippets(response.body, 0)
         # And it doesn't affect existing snippets, just empty ones.
@@ -647,7 +647,7 @@ class SetAndViewSnippetsTestCase(UserTestBase):
         url = '/update_snippet?week=02-20-2012&snippet=my+snippet'
         self.request_fetcher.get(url)
         response = self.request_fetcher.get('/')
-        self.assertNumSnippets(response.body, 1)
+        self.assertNumSnippets(response.body, 2)
         self.assertInSnippet('>my snippet<', response.body, 0)
 
     def testSetAndViewInWeeklyMode(self):
@@ -674,7 +674,7 @@ class SetAndViewSnippetsTestCase(UserTestBase):
         # This is done as other
         response = self.request_fetcher.get('/')
         self.assertIn('other@example.com', response.body)
-        self.assertNumSnippets(response.body, 1)
+        self.assertNumSnippets(response.body, 2)
         self.assertInSnippet('>other snippet<', response.body, 0)
         self.assertNotIn('user@example.com', response.body)
         self.assertNotIn('>my snippet<', response.body)
@@ -689,7 +689,7 @@ class SetAndViewSnippetsTestCase(UserTestBase):
         self.login('user@example.com')
         response = self.request_fetcher.get('/')
         self.assertIn('user@example.com', response.body)
-        self.assertNumSnippets(response.body, 1)
+        self.assertNumSnippets(response.body, 2)
         self.assertInSnippet('>my snippet<', response.body, 0)
         self.assertNotIn('other@example.com', response.body)
         self.assertNotIn('>other snippet<', response.body)
@@ -707,7 +707,7 @@ class SetAndViewSnippetsTestCase(UserTestBase):
         self.request_fetcher.get(url)
 
         response = self.request_fetcher.get('/')
-        self.assertNumSnippets(response.body, 2)
+        self.assertNumSnippets(response.body, 3)
         # Snippets go in reverse chronological order (i.e. newest first)
         self.assertInSnippet('>my second snippet<', response.body, 0)
         self.assertInSnippet('>my snippet<', response.body, 1)
@@ -834,7 +834,7 @@ class SetAndViewSnippetsTestCase(UserTestBase):
         snippets._TODAY_FN = lambda: datetime.datetime(2012, 2, 22)
         response = self.request_fetcher.get('/')
         self.assertNotIn('Due today', response.body)
-        self.assertNotIn('OVERDUE', response.body)
+        self.assertIn('OVERDUE', response.body)
 
     def testWarningsWhenNotDue(self):
         url = '/update_snippet?week=02-13-2012&snippet=my+snippet'
@@ -867,7 +867,7 @@ class SetAndViewSnippetsTestCase(UserTestBase):
         # Also make sure we urlize on the user page.
         self.login('2@example.com')
         response = self.request_fetcher.get('/?u=user@example.com')
-        self.assertNumSnippets(response.body, 1)
+        self.assertNumSnippets(response.body, 2)
         self.assertInSnippet(
             '>visit <a href="http://foo.com">http://foo.com</a><',
             response.body, 0)
@@ -958,7 +958,7 @@ class NosnippetGapFillingTestCase(UserTestBase):
         self.request_fetcher.get(url)
 
         response = self.request_fetcher.get('/')
-        self.assertNumSnippets(response.body, 1)
+        self.assertNumSnippets(response.body, 2)
 
     def testOneSnippetInDistantPast(self):
         url = '/update_snippet?week=02-21-2011&snippet=old+snippet'
@@ -987,7 +987,7 @@ class NosnippetGapFillingTestCase(UserTestBase):
         url = '/update_snippet?week=02-18-2013&snippet=future+snippet'
         self.request_fetcher.get(url)
         response = self.request_fetcher.get('/')
-        self.assertNumSnippets(response.body, 1)
+        self.assertNumSnippets(response.body, 54)
         self.assertInSnippet('future snippet', response.body, 0)
 
         response = self.request_fetcher.get('/weekly')

--- a/templates/user_snippets.html
+++ b/templates/user_snippets.html
@@ -15,7 +15,7 @@
         {% if not snippet.text and snippet.week == one_week_ago %}
         <span class="snippet-alert">Due today!</span>
         {% endif %}
-        {% if not snippet.text and snippet.week == eight_days_ago %}
+        {% if not snippet.text and snippet.week <= eight_days_ago %}
         <span class="snippet-alert">OVERDUE!</span>
         {% endif %}
       </h2>

--- a/util.py
+++ b/util.py
@@ -87,15 +87,20 @@ def existingsnippet_monday(today):
     return end_monday.date()
 
 
+_ONE_WEEK = datetime.timedelta(7)
+
+
 def _backfill_missing_snippets(user, all_snippets,
                                current_monday, first_allowed_monday):
-    monday_ptr = current_monday - datetime.timedelta(7)
-    while monday_ptr - first_allowed_monday >= datetime.timedelta(0):
+    monday_ptr = current_monday - _ONE_WEEK
+    while monday_ptr >= first_allowed_monday:
         all_snippets.insert(0,
-            Snippet(email=user.email, week=monday_ptr,
-                    private=user.private_snippets,
-                    is_markdown=user.uses_markdown))
-        monday_ptr = monday_ptr - datetime.timedelta(7)
+                            Snippet(
+                                email=user.email,
+                                week=monday_ptr,
+                                private=user.private_snippets,
+                                is_markdown=user.uses_markdown))
+        monday_ptr -= _ONE_WEEK
 
 
 def fill_in_missing_snippets(existing_snippets, user, user_email, today):
@@ -103,8 +108,10 @@ def fill_in_missing_snippets(existing_snippets, user, user_email, today):
 
     The db may have holes in it -- weeks where the user didn't write a
     snippet.  Augment the given snippets array so that it has no holes,
-    by adding in default snippet entries if necessary.  Note it does
-    not add these entries to the db, it just adds them to the array.
+    by adding in default snippet entries if necessary. Also backfill empty
+    snippets up until one week before user's registration week.
+    Note it does not add these entries to the db, it just adds them
+    to the array.
 
     Arguments:
        existing_snippets: a list of Snippet objects for a given user.
@@ -119,11 +126,14 @@ def fill_in_missing_snippets(existing_snippets, user, user_email, today):
          fill up to the current week.
 
     Returns:
-      A new list of Snippet objects, without any holes.
+      A new list of Snippet objects, without any holes,
+      up to one week before user's registration week.
     """
     end_monday = newsnippet_monday(today)
-    first_allowed_monday = newsnippet_monday(user.created) - datetime.timedelta(7)
-    if not existing_snippets:         # no snippets at all?  Just do this week
+    first_allowed_monday = newsnippet_monday(user.created) - _ONE_WEEK
+    # No snippets at all? Fill empty snippets up to one week before user's
+    # registration week.
+    if not existing_snippets:
         all_snippets = [Snippet(email=user_email, week=end_monday,
                                 private=user.private_snippets,
                                 is_markdown=user.uses_markdown)]
@@ -134,15 +144,15 @@ def fill_in_missing_snippets(existing_snippets, user, user_email, today):
     # Add a sentinel, one week past the last week we actually want.
     # We'll remove it at the end.
     existing_snippets.append(Snippet(email=user_email,
-                                     week=end_monday + datetime.timedelta(7)))
+                                     week=end_monday + _ONE_WEEK))
 
     all_snippets = [existing_snippets[0]]   # start with the oldest snippet
-    if all_snippets[0].week - first_allowed_monday >= datetime.timedelta(7):
+    if all_snippets[0].week - first_allowed_monday >= _ONE_WEEK:
         _backfill_missing_snippets(user, all_snippets,
                                    all_snippets[0].week, first_allowed_monday)
     for snippet in existing_snippets[1:]:
-        while snippet.week - all_snippets[-1].week > datetime.timedelta(7):
-            missing_week = all_snippets[-1].week + datetime.timedelta(7)
+        while snippet.week - all_snippets[-1].week > _ONE_WEEK:
+            missing_week = all_snippets[-1].week + _ONE_WEEK
             all_snippets.append(Snippet(email=user_email, week=missing_week,
                                         private=user.private_snippets,
                                         is_markdown=user.uses_markdown))


### PR DESCRIPTION
After I set up snippets server in our company, many users requested for this feature. Let me know if this is a good idea to merge it back. Thanks.