### PR TITLE
Strip _title_case input and output.

### DIFF
--- a/snippets.py
+++ b/snippets.py
@@ -226,7 +226,7 @@ def _title_case(s):
     SMALL = 'a|an|and|as|at|but|by|en|for|if|in|of|on|or|the|to|v\.?|via|vs\.?'
     # We purposefully don't match small words at the beginning of a string.
     SMALL_RE = re.compile(r' (%s)\b' % SMALL, re.I)
-    return SMALL_RE.sub(lambda m: ' ' + m.group(1).lower(), s.title())
+    return SMALL_RE.sub(lambda m: ' ' + m.group(1).lower(), s.title().strip())
 
 
 class SummaryPage(BaseHandler):

--- a/snippets_test.py
+++ b/snippets_test.py
@@ -1486,6 +1486,14 @@ class TitleCaseTestCase(unittest.TestCase):
         self.assertEqual('A Word to the Wise',
                          snippets._title_case('a wOrd to The WIse'))
 
+    def testTrimLeadingSpaces(self):
+        self.assertEqual('A Word to the Wise',
+                         snippets._title_case('  a word to the wise'))
+
+    def testTrimTrailingSpaces(self):
+        self.assertEqual('A Word to the Wise',
+                         snippets._title_case('a word to the wise  '))
+
 
 class DisplayNameTestCase(UserTestBase):
     """Manipulate a user's display name and check it in weekly page."""


### PR DESCRIPTION
So that we won't have a weird category grouping when two users' categories are like this:
`Dev`
`Dev ` (with a trailing space),

their snippets are in different categories.